### PR TITLE
Fix version cast as a date for elasticsearch

### DIFF
--- a/fluent-plugin-ua-parser.gemspec
+++ b/fluent-plugin-ua-parser.gemspec
@@ -17,9 +17,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "fluentd", [">= 0.14", "< 2"]
-  spec.add_runtime_dependency "user_agent_parser", ">= 2.2.0"
-  spec.add_runtime_dependency "lru_redux", ">= 1.0.0"
+  spec.add_runtime_dependency "fluentd", ["~> 1"]
+  spec.add_runtime_dependency "user_agent_parser", "~> 2.2"
+  spec.add_runtime_dependency "lru_redux", "~> 1.0"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit"

--- a/lib/fluent/plugin/filter_ua_parser.rb
+++ b/lib/fluent/plugin/filter_ua_parser.rb
@@ -7,7 +7,7 @@ module Fluent::Plugin
     Fluent::Plugin.register_filter('ua_parser', self)
 
     def initialize
-      @ua_cache = LruRedux::Cache.new(512)
+      @ua_cache = LruRedux::Cache.new(4096)
       super
     end
 

--- a/lib/fluent/plugin/filter_ua_parser.rb
+++ b/lib/fluent/plugin/filter_ua_parser.rb
@@ -7,7 +7,7 @@ module Fluent::Plugin
     Fluent::Plugin.register_filter('ua_parser', self)
 
     def initialize
-      @ua_cache = LruRedux::Cache.new(4096)
+      @ua_cache = LruRedux::Cache.new(512)
       super
     end
 
@@ -49,10 +49,10 @@ module Fluent::Plugin
       data = {"browser"=>{}, "os"=>{}, "device"=>""}
       return data if ua.nil?
       data['browser']['family'] = ua.family
-      data['browser']['version'] = ua.version.to_s
+      data['browser']['version'] = ua.version.to_s.gsub(/(\d*\.\d*.\d*)(\.\d*)/,'\1')
       data['browser']['major_version'] = ua.version.major.to_i unless ua.version.nil?
-      data['os']['family'] = ua.os.family
-      data['os']['version'] = ua.os.version.to_s
+      data['os']['family'] = ua.os.family.to_s
+      data['os']['version'] = ua.os.version.to_s.gsub(/(\d*\.\d*.\d*)(\.\d*)/,'\1')
       data['os']['major_version'] = ua.os.version.major.to_i unless ua.os.version.nil?
       data['device'] = ua.device.to_s
       data

--- a/test/plugin/test_filter_ua_parser.rb
+++ b/test/plugin/test_filter_ua_parser.rb
@@ -35,8 +35,8 @@ class UaParserFilterTest < Test::Unit::TestCase
     assert_equal 'Chrome', ua_object['browser']['family']
     assert_equal 46, ua_object['browser']['major_version']
     assert_equal '46.0.2490', ua_object['browser']['version']
-    assert_equal 'Windows 7', ua_object['os']['family']
-    assert_equal '', ua_object['os']['version']
+    assert_equal 'Windows', ua_object['os']['family']
+    assert_equal '7', ua_object['os']['version']
     assert_equal 'Other', ua_object['device']
   end
 
@@ -56,8 +56,8 @@ class UaParserFilterTest < Test::Unit::TestCase
     assert_equal 'Chrome', ua_object['ua_browser_family']
     assert_equal 46, ua_object['ua_browser_major_version']
     assert_equal '46.0.2490', ua_object['ua_browser_version']
-    assert_equal 'Windows 7', ua_object['ua_os_family']
-    assert_equal '', ua_object['ua_os_version']
+    assert_equal 'Windows', ua_object['ua_os_family']
+    assert_equal '7', ua_object['ua_os_version']
     assert_equal 'Other', ua_object['ua_device']
   end
 


### PR DESCRIPTION
Forth level version number are casts by date, i've added a restriction on the third level of this version to avoid this issue

[issue#17](https://github.com/bungoume/fluent-plugin-ua-parser/pull/18/commits/1e85e549647eedac015f572a922d9624c3200376)